### PR TITLE
Various fixes changing from .gz to .xz, extend README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN mkdir -p /usr/src/aiscm
 WORKDIR /usr/src/aiscm
 ADD debian/control debian/control
 RUN mk-build-deps --install --remove --tool 'apt-get -q --yes' debian/control
-COPY aiscm.tar.gz .
-COPY aiscm.tar.gz.asc .
+COPY aiscm.tar.xz .
+COPY aiscm.tar.xz.asc .
 ADD configure.ac .
 ADD debian debian
 ADD Makefile.package .

--- a/Makefile.package
+++ b/Makefile.package
@@ -2,10 +2,10 @@ VERSION=$(shell grep AC_INIT configure.ac | sed -e "s/.*\[\([0-9\.]*\)\].*/\1/")
 
 # https://wiki.debian.org/IntroDebianPackaging
 # https://en.opensuse.org/openSUSE:Build_Service_Tutorial
-package: aiscm.tar.gz aiscm.tar.gz.asc
+package: aiscm.tar.xz aiscm.tar.xz.asc
 	mkdir -p pkg
-	cp aiscm.tar.gz pkg/aiscm_$(VERSION).orig.tar.gz
-	cp aiscm.tar.gz.asc pkg/aiscm_$(VERSION).orig.tar.gz.asc
-	tar xzf aiscm.tar.gz -C pkg
+	cp aiscm.tar.xz pkg/aiscm_$(VERSION).orig.tar.xz
+	cp aiscm.tar.xz.asc pkg/aiscm_$(VERSION).orig.tar.xz.asc
+	tar xf aiscm.tar.xz -C pkg
 	cp -a debian pkg/aiscm-$(VERSION)
 	cd pkg/aiscm-$(VERSION) && debuild -us -uc -j4 && cd ../..

--- a/README.md
+++ b/README.md
@@ -67,6 +67,38 @@ sudo make install
 cd ..
 ```
 
+### Installation using Docker
+
+Download the `.tar.xz` and the `.tar.xz.asc` files from the
+lastest [release](https://github.com/wedesoft/aiscm/releases) into the root folder of the cloned repository, then rename
+the files to `aiscm.tar.gz` and `aiscm.tar.gz.asc`, respectively.
+
+Build the Docker image using the command below, where the second line just display some minimal information about the
+image. Note that the Docker build will take *some* time.
+
+```Shell
+docker build --tag=aiscm .
+docker image ls aiscm
+```
+
+Now can can start a shell within your running container using:
+
+```Shell
+docker run -w /usr/src/aiscm/pkg/aiscm-{release-number} -it aiscm /bin/bash
+# e.g.: docker run -w /usr/src/aiscm/pkg/aiscm-0.18.1 -it aiscm /bin/bash
+```
+
+Within the `tests` folder, you'll find that all unit tests have already been run; you might also have seen the
+respective log output during `docker build`. Integration tests are not yet completely running within Docker, but you can
+e.g. run one using:
+
+```Shell
+cd tests/integration/
+make 2d_array.tmp
+```
+
+See below for more information on running the tests.
+
 ## Run tests
 
 ### Unit tests


### PR DESCRIPTION
Got some errors when trying to run the Dockerfile, caused by the Dockerfile and Makefile.package still assuming .gz file extension, where releases now use .xz file extension.

Also added short section on how to build and run the Docker container - with not much of an idea what to do inside ;)

Incredible piece of work, btw.!

Grüße aus dem Süden, Frank
